### PR TITLE
Update to support Whole Number and Float

### DIFF
--- a/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Class/RollupFunctions.cs
+++ b/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Class/RollupFunctions.cs
@@ -206,7 +206,7 @@ namespace msdyncrmWorkflowTools
             {
                 return ((Money)obj).Value;
             }
-            else if (obj is decimal)
+            else if (obj is decimal || obj is int || obj is long || obj is short || obj is float || obj is double)
             { 
                 return Convert.ToDecimal(obj);
             }


### PR DESCRIPTION
The current Rollup Function only supports Decimal or Money, while it can support Whole number or float or any other number.