### PR TITLE
Fix regex function

### DIFF
--- a/msdyncrmWorkflowTools/msdyncrmWorkflowTools_Class/msdyncrmWorkflowTools_Class.cs
+++ b/msdyncrmWorkflowTools/msdyncrmWorkflowTools_Class/msdyncrmWorkflowTools_Class.cs
@@ -451,16 +451,15 @@ namespace msdyncrmWorkflowTools
             regexSuccess = false;
             if (regularExpression != "")
             {
-                Regex regex = new Regex(regularExpression);
-                Match match = regex.Match(inputText);
+                Regex regex_value = new Regex(regularExpression);
+                Match match = regex_value.Match(inputText);
                 if (match.Success)
                 {
                     regexSuccess = true;
-                    regexText = match.Value;
+                    regexText = regex_value.Replace(inputText, "");
                 }
 
             }
-
             uppercaseText = inputText.ToUpper();
             lowercaseText = inputText.ToLower();
 


### PR DESCRIPTION
After reviewing issues #271 and #146, it appears that the regex function currently returns only the first occurrence (regex.Match) rather than the entire expression. 
With this modification, we will be able to retrieve the complete expression using the regex rule.