### PR TITLE
Common.CloneRecord & Common.CloneChildren Bringing changes that should solve issue #255 allowing to have fields to ignore

### DIFF
--- a/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Class/CloneChildren.cs
+++ b/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Class/CloneChildren.cs
@@ -119,21 +119,19 @@ namespace msdyncrmWorkflowTools
             var tools = new msdyncrmWorkflowTools_Class(objCommon.service);
 
             var children = tools.GetChildRecords(_relationshipName, parentId);
-             
+
+            var fieldsToReplace = new Dictionary<string, object>
+            {
+                { _newParentFieldName, new EntityReference(destinationEntityName, new Guid(destinationId)) }
+            };
+            if (!string.IsNullOrEmpty(_oldParentFieldName) && _oldParentFieldName != _newParentFieldName)
+            {
+                fieldsToReplace.Add(_oldParentFieldName, null);
+            }
+
             foreach (var item in children.Entities)
             {
-                var newRecordId = objCommon.CloneRecord(item.LogicalName, item.Id.ToString(), fieldstoIgnore, prefix);
-
-                Entity update = new Entity(item.LogicalName);
-                update.Id = newRecordId;
-                update.Attributes.Add(_newParentFieldName, new EntityReference(destinationEntityName, new Guid(destinationId)));
-                if (!string.IsNullOrEmpty(_oldParentFieldName) && _oldParentFieldName != _newParentFieldName)
-                {
-                    update.Attributes.Add(_oldParentFieldName, null);
-                }
-
-                objCommon.service.Update(update);
-
+                _ = objCommon.CloneRecord(item.LogicalName, item.Id.ToString(), fieldstoIgnore, prefix, fieldsToReplace);
             }
             
 

--- a/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Common.cs
+++ b/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Common.cs
@@ -121,7 +121,7 @@ namespace msdyncrmWorkflowTools
             return (atts);
         }
 
-        public Guid CloneRecord(string entityName, string objectId, string fieldstoIgnore, string prefix)
+        public Guid CloneRecord(string entityName, string objectId, string fieldstoIgnore, string prefix, Dictionary<string, object> fieldsToReplace = null)
         {
             tracingService.Trace("entering CloneRecord");
             if (fieldstoIgnore == null) fieldstoIgnore = "";
@@ -198,6 +198,22 @@ namespace msdyncrmWorkflowTools
                         retrievedObject.Attributes[att] = prefix + retrievedObject.Attributes[att];
                     }
                     newEntity.Attributes.Add(att, retrievedObject.Attributes[att]);
+                }
+            }
+
+            if (fieldsToReplace != null)
+            {
+                foreach (KeyValuePair<string, object> replaceField in fieldsToReplace)
+                {
+                    tracingService.Trace("attribute:{0}", replaceField.Key);
+                    if (newEntity.Attributes.ContainsKey(replaceField.Key))
+                    {
+                        newEntity[replaceField.Key] = replaceField.Value;
+                    }
+                    else
+                    {
+                        newEntity.Attributes.Add(replaceField.Key, replaceField.Value);
+                    }
                 }
             }
 


### PR DESCRIPTION
[Common.CloneRecord fieldToReplace](https://github.com/demianrasko/Dynamics-365-Workflow-Tools/commit/54c4e0d9c9c8e9bfb6fd97544c291a661c9466af)
Moved logic that updates parent record ID on clone into core CloneRecord logic. Fix for issue https://github.com/demianrasko/Dynamics-365-Workflow-Tools/issues/255.

